### PR TITLE
[FEAT]: add OpenVPN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Once it is installed, follow these steps:
 4. In the 'horus' directory, run ```python3 horus.py``` on Linux/MacOS, or ```py horus.py``` on Windows
 
 *Note: protonvpn-cli is a requirement for the 'pvpn' command*
+*Note: openvpn CLI is a requirement for the 'ovpn' command*
 
 ## ⚙️ API Configuration
 To configure the APIs necessary for usage of certain commands, you can either manually enter them, or use the 'apicon' command

--- a/horus.py
+++ b/horus.py
@@ -10,6 +10,7 @@ import src.main as main
 # Modules
 import src.apicon as apicon
 # # SECURITY.
+import src.modules.ovpn as ovpn
 import src.modules.pvpn as pvpn
 # ENUMERATION.
 import src.modules.recpull as recpull
@@ -45,7 +46,7 @@ ap.add_argument('-apicon', help='Configure the API settings for Horus\n', action
 # SECURITY.
 #ap.add_argument('-Torshell', help='\n', action="store_true")
 ap.add_argument('-pvpn', help='\n', action="store_true")
-#ap.add_argument('-Ovpn', help='\n', action="store_true")
+ap.add_argument('-ovpn', help='Connect to an OpenVPN server using a config/profile file.\n', action="store_true")
 # ENUMERATION.
 #ap.add_argument('-Fallenflare', help='\n', action="store_true")
 ap.add_argument('-recpull', help='\n', action="store_true")
@@ -114,6 +115,14 @@ if args['pvpn']: # Runs the pvpn program.
         except Exception as error:
             print(f">_ {Fore.RED}FAILURE{Fore.WHITE}: {error}\n")
             os._exit(0)
+
+if args['ovpn']:
+    while True:
+        try:
+            ovpn.ovpn()
+            os._exit(0)
+        except Exception as error:
+            print(f">_ {Fore.RED}FAILURE{Fore.WHITE}: {error}\n")
 
 if args['shodan']: # Runs the shodan program.
     while True:

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ import src.modules.loki_decrypt as loki_decrypt
 import src.modules.cryptotrace as cryptotrace
 import src.modules.vt as vt
 import src.modules.mactrace as mactrace
+import src.modules.ovpn as ovpn
 import src.modules.pvpn as pvpn
 import src.modules.flightinfo as flightinfo
 import src.modules.wigle as wigle
@@ -70,7 +71,7 @@ def main_script():
                 "Torshell | Drop into a Tor sub-shell, or connect to Tor.")
             command(Fore.GREEN,
                 "Pvpn | Connect to a random Proton vpn.")
-            command(Fore.RED,
+            command(Fore.YELLOW,
                 "Ovpn | Connect to a specified open vpn.")
             section("ENUMERATION") #################
             command(Fore.YELLOW,
@@ -136,7 +137,7 @@ def main_script():
                 "Falcon | Packet analysis; sniff for your own in the terminal or use a capture file!")
             print(f"\n{notice}  Remember; run `apicon` command to configure the API database.")
 
-            option = input(f"{prompt}")
+            option = input(f"{prompt} ")
             # SECURITY.
             # ENUMERATION.
             # OSINT.
@@ -159,6 +160,10 @@ def main_script():
             if option.lower() == "vt":
               vt.vt()
               os._exit(0)
+
+            if option.lower() == "ovpn":
+                ovpn.ovpn()
+                os._exit(0)
 
             if option.lower() == "pvpn":
               pvpn.pvpn()

--- a/src/modules/ovpn.py
+++ b/src/modules/ovpn.py
@@ -17,8 +17,7 @@ text = (f"{Fore.WHITE}")  # Change the colour of text output in the client side
 # Changes the [], | and : in the client side
 dividers = (f"{Fore.LIGHTRED_EX}")
 # Success output.
-success = (f"\n{Fore.WHITE}[{Fore.GREEN}SUCCESS{
-           Fore.WHITE}] Program executed sucessfully.")
+success = (f"\n{Fore.WHITE}[{Fore.GREEN}SUCCESS{Fore.WHITE}] Program executed successfully.")
 response = (f"{Fore.WHITE}[{Fore.GREEN}+{Fore.WHITE}]")
 # Successfully output.
 successfully = (f"{Fore.WHITE}[{Fore.GREEN}SUCCESSFULLY{Fore.WHITE}]")
@@ -36,7 +35,7 @@ disconnected = (f"{Fore.WHITE}[{Fore.LIGHTRED_EX}DISCONNECTED{Fore.WHITE}]")
 command = (f"\n[{Fore.YELLOW}>_{Fore.WHITE}]: ")
 
 # Pre-run.
-os.system("clear")      
+os.system("clear")
 
 # Hide tracebacks - change to 1 for dev mode.
 sys.tracebacklimit = 0
@@ -46,12 +45,14 @@ sys.tracebacklimit = 0
 PROC_ID = multiprocessing.Value('i', 0)
 PLATFORM = sys.platform
 
+
 # --------------------------------
 # Helper functions
 # --------------------------------
 def has_dependencies_installed() -> bool:
     exec_path = shutil.which("openvpn")
     return exec_path and os.access(exec_path, os.X_OK)
+
 
 def get_links_by_platform() -> (str, str, str, str):
     global PLATFORM
@@ -78,8 +79,9 @@ def get_links_by_platform() -> (str, str, str, str):
         mullvad = "https://mullvad.net/en/help/tunnelblick-mac"
     else:
         raise Exception("Unsupported platform")
-    
+
     return openvpn, proton, nord, mullvad
+
 
 def has_files_in_dir(directory: str, pattern: str) -> bool:
     """
@@ -88,12 +90,14 @@ def has_files_in_dir(directory: str, pattern: str) -> bool:
     files = glob.glob(os.path.join(directory, pattern))
     return files and len(files) > 0
 
+
 def list_files_in_dir(directory: str):
     """
     Lists all the files in a directory
     """
     files = glob.glob(os.path.join(directory, "*"))
     [print(file) for file in files]
+
 
 def is_admin():
     try:
@@ -103,6 +107,7 @@ def is_admin():
 
     return admin
 # --------------------------------
+
 
 def get_windows_command_and_path(config_file_path: str) -> (list, str):
     """
@@ -120,7 +125,7 @@ def get_windows_command_and_path(config_file_path: str) -> (list, str):
     """
     command = []
     windows_path = "C:\\Program Files\\OpenVPN\\bin\\openvpn-gui.exe"
-    config_path = "C:\\Program Files\\OpenVPN\\config\\"    
+    config_path = "C:\\Program Files\\OpenVPN\\config\\"
     config_file_name = config_file_path.split("\\")[-1]
 
     command = [windows_path, "--connect", config_file_name]
@@ -132,12 +137,12 @@ def get_windows_command_and_path(config_file_path: str) -> (list, str):
         print(f"{notice} Config file already exists in {config_path}. Executing...")
 
     return command, config_path
-    
 
-def connect(config_file_path: str, move = False) -> subprocess.Popen:
+
+def connect(config_file_path: str, move=False) -> subprocess.Popen:
     """
     Call the underlying openvpn command to connect to the VPN server.
-        
+
     If run on Windows, move the config file to the OpenVPN config directory to make running the program easier.
 
     Linux and MacOS do not need the config file to be moved.
@@ -184,22 +189,22 @@ def connect(config_file_path: str, move = False) -> subprocess.Popen:
                 break
             else:
                 print(line.decode().strip())
-            
+
         return proc
     except subprocess.CalledProcessError as e:
-        print(f"{alert} Error executing command: {e}")  
+        print(f"{alert} Error executing command: {e}")
     except Exception as e:
         print(f"{alert} An error occurred: {e}")
 
 
-def process(config_path: str, move = False) -> (multiprocessing.Process, int):
+def process(config_path: str, move=False) -> (multiprocessing.Process, int):
     """
     This function is the main entry point of the program. It takes a config file path and an optional 'move' flag.
 
     The 'move' flag is determined by whether there are "authentication" files in the same folder as the config file. Some
-    providers include the authentication and certs in the config file itself, others include them in separate files and 
+    providers include the authentication and certs in the config file itself, others include them in separate files and
     then refer to those in the config file using relative paths.
-    
+
     Args:
         config_path (str): The path to the OpenVPN configuration file.
         move (bool): If True, the program will change directory to the same as the config file before execution.
@@ -207,7 +212,7 @@ def process(config_path: str, move = False) -> (multiprocessing.Process, int):
     Returns:
         None
     """
-    
+
     global PLATFORM
     global PROC_ID
 
@@ -217,8 +222,8 @@ def process(config_path: str, move = False) -> (multiprocessing.Process, int):
     while running:
         try:
             if not PROC_ID.value or PROC_ID.value == 0:
-                
-                # On Windows, multiprocessing imports the main script and executes it, causing all of the intro text to display 
+
+                # On Windows, multiprocessing imports the main script and executes it, causing all of the intro text to display
                 # again. It doesn't break anything but it looks bad and confusing.
                 if PLATFORM != "win32":
                     print(f"{alert} openvpn requires admin permissions. You might be asked to enter your password")
@@ -233,7 +238,7 @@ def process(config_path: str, move = False) -> (multiprocessing.Process, int):
 
                 if not proc:
                     print(f"{alert} Error connecting to VPN")
-                    running = False             
+                    running = False
 
             proc_id = PROC_ID.value
             print(f"{response} VPN is connected using process {proc_id}")
@@ -244,7 +249,7 @@ def process(config_path: str, move = False) -> (multiprocessing.Process, int):
 
             if PROC_ID and PROC_ID.value != 0:
                 os.kill(PROC_ID.value, signal.SIGTERM)
-            PROC_ID.value = 0  
+            PROC_ID.value = 0
 
     if proc_id and proc_id != 0:
         print(f"{notice} VPN process is running as process ID {proc_id}. If you wish to stop it, run: sudo kill -9 {proc_id} or restarting the computer will end it.")
@@ -270,7 +275,7 @@ def ovpn():
             if PLATFORM == "win32" and not is_admin():
                 print(f"{alert} This program does support Windows but you will need to run in Administrator Mode.")
                 return
-        
+
             path = input(
                 f"{prompt} Enter the filepath to your OpenVPN connection profile (*.ovpn file): "
             )
@@ -281,8 +286,8 @@ def ovpn():
 
             if move == 'unsure':
                 if (
-                    has_files_in_dir(Path(path).resolve(),"*.crt")
-                    or has_files_in_dir(Path(path).resolve(),"*_userpass.txt")
+                    has_files_in_dir(Path(path).resolve(), "*.crt")
+                    or has_files_in_dir(Path(path).resolve(), "*_userpass.txt")
                 ):
                     move = "y"
 

--- a/src/modules/ovpn.py
+++ b/src/modules/ovpn.py
@@ -1,0 +1,224 @@
+# Imports.
+import glob
+import multiprocessing
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+from colorama import Fore  # For text colour.
+from pathlib import Path
+
+# Config (Prints).
+text = (f"{Fore.WHITE}")  # Change the colour of text output in the client side
+# Changes the [], | and : in the client side
+dividers = (f"{Fore.LIGHTRED_EX}")
+# Success output.
+success = (f"\n{Fore.WHITE}[{Fore.GREEN}SUCCESS{
+           Fore.WHITE}] Program executed sucessfully.")
+response = (f"{Fore.WHITE}[{Fore.GREEN}+{Fore.WHITE}]")
+# Successfully output.
+successfully = (f"{Fore.WHITE}[{Fore.GREEN}SUCCESSFULLY{Fore.WHITE}]")
+# Failed output.
+failed = (f"{Fore.WHITE}[{Fore.LIGHTRED_EX}FAILED{Fore.WHITE}]")
+prompt = (f"{Fore.WHITE}[{Fore.YELLOW}»{Fore.WHITE}]")  # Prompt output.
+notice = (f"{Fore.WHITE}[{Fore.YELLOW}!{Fore.WHITE}]")  # Notice output.
+question = (f"{Fore.WHITE}[{Fore.YELLOW}?{Fore.WHITE}]")  # Alert output.
+alert = (f"{Fore.WHITE}[{Fore.LIGHTRED_EX}!{Fore.WHITE}]")  # Alert output.
+# Execited output.
+exited = (f"{Fore.WHITE}[{Fore.LIGHTRED_EX}EXITED{Fore.WHITE}]")
+# Disconnected output.
+disconnected = (f"{Fore.WHITE}[{Fore.LIGHTRED_EX}DISCONNECTED{Fore.WHITE}]")
+# Always asks for a command on a new line.
+command = (f"\n[{Fore.YELLOW}>_{Fore.WHITE}]: ")
+
+# Pre-run.
+os.system("clear")      
+
+# Hide tracebacks - change to 1 for dev mode.
+sys.tracebacklimit = 0
+
+# Program.
+
+PROC_ID = multiprocessing.Value('i', 0)
+PLATFORM = sys.platform
+
+# --------------------------------
+# Helper functions
+# --------------------------------
+def has_dependencies_installed():
+    exec_path = shutil.which("openvpn")
+    return exec_path and os.access(exec_path, os.X_OK)
+
+def get_links_by_platform():
+    global PLATFORM
+
+    openvpn = ''
+    proton = ''
+    nord = ''
+    mullvad = ''
+
+    if PLATFORM == "linux":
+        openvpn = "https://openvpn.net/openvpn-client-for-linux/"
+        nord = "https://support.nordvpn.com/hc/en-us/articles/20164827795345-Connect-to-NordVPN-using-Linux-Terminal"
+        proton = "https://protonvpn.com/support/linux-openvpn/"
+        mullvad = "https://mullvad.net/en/help/linux-openvpn-installation"
+    elif PLATFORM == "windows":
+        openvpn = "https://openvpn.net/connect-docs/installation-guide-windows.html"
+        nord = "https://support.nordvpn.com/hc/en-us/articles/19749554331793-How-to-set-up-a-manual-connection-on-Windows-using-OpenVPN"
+        proton = "https://protonvpn.com/support/openvpn-windows-setup/"
+        mullvad = "https://mullvad.net/en/help/windows-openvpn-installation"
+    elif PLATFORM == "macos":
+        openvpn = "https://openvpn.net/connect-docs/connect-for-macos.html"
+        proton = "https://protonvpn.com/support/mac-vpn-setup/"
+        nord = "https://support.nordvpn.com/hc/en-us/articles/19924903986961-Manual-connection-setup-with-Tunnelblick-on-macOS"
+        mullvad = "https://mullvad.net/en/help/tunnelblick-mac"
+    else:
+        raise Exception("Unsupported platform")
+    
+    return openvpn, proton, nord, mullvad
+
+def has_files_in_dir(directory: str, pattern: str) -> list[str]:
+    """
+    Checks if a directory contains any file that matches the given pattern
+    """
+    files = glob.glob(os.path.join(directory, pattern))
+    return files and len(files) > 0
+
+# --------------------------------
+
+def connect(config_path: str, move = False):
+    """
+    Call the underlying openvpn command to connect to the VPN server.
+
+    Args:
+        config_path (str): Path to the OpenVPN configuration file.
+        move (bool, optional): Move into the directory of the config file before connecting. Defaults to False.
+
+    Returns:
+        None
+    """
+    global PROC_ID
+    global PLATFORM
+
+    if move:
+        os.chdir(os.path.dirname(config_path))
+
+    try:
+        proc = subprocess.Popen(
+            ["sudo", "openvpn", "--config", config_path],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
+        )
+
+        while True:
+            line = proc.stdout.readline()
+            if 'Initialization Sequence Completed' in line.decode():
+                print(f"{response} OpenVPN initialized")
+                PROC_ID.value = proc.pid
+                break
+
+    except subprocess.CalledProcessError as e:
+        print(f"{alert} Error executing command: {e}")  
+    except Exception as e:
+        print(f"{alert} An error occurred: {e}")
+
+
+def process(config_path: str, move = False):
+    """
+    This function is the main entry point of the program. It takes a config file path and an optional 'move' flag.
+
+    The 'move' flag is determined by whether there are "authentication" files in the same folder as the config file. Some
+    providers include the authentication and certs in the config file itself, others include them in separate files and 
+    then refer to those in the config file using relative paths.
+    
+    Args:
+        config_path (str): The path to the OpenVPN configuration file.
+        move (bool): If True, the program will change directory to the same as the config file before execution.
+
+    Returns:
+        None
+    """
+    
+    global PROC_ID
+    proc_id = None
+    running = True
+
+    while running:
+        try:
+            if not PROC_ID.value or PROC_ID.value == 0:
+                print(f"{alert} openvpn requires admin permissions. You might be asked to enter your password")
+                proc = multiprocessing.Process(target=connect, args=(config_path, move,))
+                proc.start()
+
+                while not PROC_ID.value or PROC_ID.value == 0:
+                    time.sleep(1)
+
+                if not proc:
+                    print(f"{alert} Error connecting to VPN")
+                    running = False             
+
+            proc_id = PROC_ID.value
+            print(f"{response} VPN is connected using process {proc_id}")
+            break
+        except KeyboardInterrupt:
+            proc.terminate()
+            running = False
+
+            if PROC_ID and PROC_ID.value != 0:
+                os.kill(PROC_ID.value, signal.SIGTERM)
+            PROC_ID.value = 0  
+
+    if proc_id:
+        print(f"{notice} VPN process is running as process ID {proc_id}. If you wish to stop it, run: sudo kill -9 {proc_id} or restarting the computer will end it.")
+
+    sys.exit(0)
+
+    return proc, proc_id
+
+
+def ovpn():
+    global PLATFORM
+
+    openvpn, proton, nord, mullvad = get_links_by_platform()
+
+    if not has_dependencies_installed():
+        print(f"{alert} OpenVPN is required but is not installed.")
+        print(f"Please install it using your package manager or by following the instructions here: {openvpn}")
+
+    while True:
+        # Prompt for option.
+        print(f"\n{prompt} What would you like to do? [Connect, Config]")
+        option = input(f"{command}").lower()
+
+        if option == "connect":
+            path = input(
+                f"{prompt} Enter the FULLY QUALIFIED filepath to your OpenVPN connection profile (*.ovpn file): "
+            )
+            move = input(f"{alert}{prompt} Are there any auth files in the same folder as your ovpn profile? Such as a *.crt and *_userpass.txt [y/n/unsure] ").lower()
+
+            if move == 'unsure':
+                if (
+                    has_files_in_dir(Path(path).resolve(),"*.crt")
+                    or has_files_in_dir(Path(path).resolve(),"*_userpass.txt")
+                ):
+                    move = "y"
+
+            if Path(path).is_file():
+                proc, proc_id = process(Path(path).resolve(), move == 'y')
+                return proc
+            else:
+                print(f"{alert} Supplied config file does not exist, try again.")
+        elif option == "config":
+            print(f"{alert} We can't set up the OpenVPN config file for any particular provider, but here are some helpful links for how to get started:")
+            print(f"\tProton VPN: {proton}")
+            print(f"\tNord VPN: {nord}")
+            print(f"\tMullvad: {mullvad}")
+        else:
+            print(f"{alert} Invalid option. Exiting.")
+            return None
+
+
+if __name__ == '__main__':
+    ovpn()

--- a/src/modules/ovpn.py
+++ b/src/modules/ovpn.py
@@ -48,11 +48,11 @@ PLATFORM = sys.platform
 # --------------------------------
 # Helper functions
 # --------------------------------
-def has_dependencies_installed():
+def has_dependencies_installed() -> bool:
     exec_path = shutil.which("openvpn")
     return exec_path and os.access(exec_path, os.X_OK)
 
-def get_links_by_platform():
+def get_links_by_platform() -> (str, str, str, str):
     global PLATFORM
 
     openvpn = ''
@@ -70,7 +70,7 @@ def get_links_by_platform():
         nord = "https://support.nordvpn.com/hc/en-us/articles/19749554331793-How-to-set-up-a-manual-connection-on-Windows-using-OpenVPN"
         proton = "https://protonvpn.com/support/openvpn-windows-setup/"
         mullvad = "https://mullvad.net/en/help/windows-openvpn-installation"
-    elif PLATFORM == "macos":
+    elif PLATFORM == "darwin":
         openvpn = "https://openvpn.net/connect-docs/connect-for-macos.html"
         proton = "https://protonvpn.com/support/mac-vpn-setup/"
         nord = "https://support.nordvpn.com/hc/en-us/articles/19924903986961-Manual-connection-setup-with-Tunnelblick-on-macOS"
@@ -80,7 +80,7 @@ def get_links_by_platform():
     
     return openvpn, proton, nord, mullvad
 
-def has_files_in_dir(directory: str, pattern: str) -> list[str]:
+def has_files_in_dir(directory: str, pattern: str) -> bool:
     """
     Checks if a directory contains any file that matches the given pattern
     """
@@ -125,7 +125,7 @@ def connect(config_path: str, move = False):
         print(f"{alert} An error occurred: {e}")
 
 
-def process(config_path: str, move = False):
+def process(config_path: str, move = False) -> (multiprocessing.Process, int):
     """
     This function is the main entry point of the program. It takes a config file path and an optional 'move' flag.
 
@@ -172,8 +172,6 @@ def process(config_path: str, move = False):
 
     if proc_id:
         print(f"{notice} VPN process is running as process ID {proc_id}. If you wish to stop it, run: sudo kill -9 {proc_id} or restarting the computer will end it.")
-
-    sys.exit(0)
 
     return proc, proc_id
 

--- a/src/modules/ovpn.py
+++ b/src/modules/ovpn.py
@@ -60,12 +60,12 @@ def get_links_by_platform():
     nord = ''
     mullvad = ''
 
-    if PLATFORM == "linux":
+    if PLATFORM.startswith("linux"):
         openvpn = "https://openvpn.net/openvpn-client-for-linux/"
         nord = "https://support.nordvpn.com/hc/en-us/articles/20164827795345-Connect-to-NordVPN-using-Linux-Terminal"
         proton = "https://protonvpn.com/support/linux-openvpn/"
         mullvad = "https://mullvad.net/en/help/linux-openvpn-installation"
-    elif PLATFORM == "windows":
+    elif PLATFORM == "win32":
         openvpn = "https://openvpn.net/connect-docs/installation-guide-windows.html"
         nord = "https://support.nordvpn.com/hc/en-us/articles/19749554331793-How-to-set-up-a-manual-connection-on-Windows-using-OpenVPN"
         proton = "https://protonvpn.com/support/openvpn-windows-setup/"


### PR DESCRIPTION
 ## Add support for connecting to an OpenVPN server using a config/profile file (*.ovpn)

Fixes/Implements: #10 

*Since this is my first PR on this repo, brutal honesty would be fantastic. I've tried to keep to the notes from `CONTRIBUTING.md` but have likely missed something. I haven't added any unit tests because I noticed there aren't really any but if this is something you'd like, I can absolutely add some (I would be happy to start adding some more as a separate PR for the project as a whole).*

I've made sure to have Windows support but due to how OpenVPN works in Windows there are some workarounds and differences to get it to work correctly and not cause anything that might be confusing for users.

- `multiprocessing` usage in Windows causes the whole `main` script to be re-run, rendering the ASCII again, which looks wrong so I've not used it (the process still returns correctly)
- Windows uses the GUI version of `openvpn` because the compiled version available for Windows does not support compression which can cause some configs to fail to start.

I added a lot of print statements to help users figure out how to get started with getting an OpenVPN provider/config file because trying to do that manually would be incredibly difficult. 

